### PR TITLE
[ticket/40] Load phpBB database schema

### DIFF
--- a/tests/test_framework/blog_database_test_connection_manager.php
+++ b/tests/test_framework/blog_database_test_connection_manager.php
@@ -11,5 +11,8 @@ class blog_database_test_connection_manager extends phpbb_database_test_connecti
 
 		$directory = dirname(__FILE__) . '/../../docs/schemas/';
 		$this->load_schema_from_file($directory);
+
+		// Also load the phpBB schema's
+		parent::load_schema();
 	}
 }


### PR DESCRIPTION
When the test database is initialise also include the phpBB schema files. This ensures
that the test database is setup identically to a production environment.

TICKET-#40
